### PR TITLE
Potential fix for code scanning alert no. 38: Uncontrolled data used in path expression

### DIFF
--- a/backend/engine/tts_engine.py
+++ b/backend/engine/tts_engine.py
@@ -5,6 +5,7 @@ import logging
 import math
 import os
 import random
+import re
 import struct
 import uuid
 
@@ -174,14 +175,36 @@ def _parse_l16_sample_rate(mime_type: str) -> int:
     return default_rate
 
 
+_SAFE_PATH_COMPONENT_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+
+
+def _sanitize_path_component(value: Optional[str]) -> Optional[str]:
+    """Return a safe single path component, or None when invalid."""
+    if value is None:
+        return None
+    candidate = str(value).strip()
+    if not candidate:
+        return None
+    if any(sep in candidate for sep in (os.sep, os.altsep) if sep):
+        return None
+    if candidate in {".", ".."} or ".." in candidate:
+        return None
+    if not _SAFE_PATH_COMPONENT_RE.fullmatch(candidate):
+        return None
+    return candidate
+
+
 def _resolve_audio_output_dir(adventure_id: Optional[str], session_id: Optional[str] = None) -> str:
     """Return target directory for generated audio.
 
     If adventure_id + session_id are known, store clips under that concrete session.
     Otherwise, keep legacy global fallback for compatibility.
     """
-    if session_id:
-        return os.path.join(settings.DATA_DIR, "adventures", "sessions", session_id, "tts")
+    safe_session_id = _sanitize_path_component(session_id)
+    if session_id and not safe_session_id:
+        logger.warning("Invalid session_id for audio output path; using global audio fallback.")
+    if safe_session_id:
+        return os.path.join(settings.DATA_DIR, "adventures", "sessions", safe_session_id, "tts")
     return os.path.join(settings.DATA_DIR, "audio")
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/jschm42/taleweaver/security/code-scanning/38](https://github.com/jschm42/taleweaver/security/code-scanning/38)

The safest fix is to ensure `session_id` cannot influence path traversal by validating/sanitizing it before path construction, and falling back to legacy safe storage when invalid.  
Best single fix without changing intended functionality: in `backend/engine/tts_engine.py`, add a helper that accepts only a strict identifier format (UUID-style plus safe `[A-Za-z0-9_-]`), rejects path separators / `..`, and use it in `_resolve_audio_output_dir` before joining into the path.

Concretely:
- Edit `backend/engine/tts_engine.py`.
- Add `import re`.
- Add helper `_sanitize_path_component(value: Optional[str]) -> Optional[str]`.
- Update `_resolve_audio_output_dir(...)` to use sanitized `session_id`; if invalid, log warning and return legacy `settings.DATA_DIR/audio` path.
- Keep existing behavior for valid session IDs and all other logic unchanged.

This removes uncontrolled path usage while preserving current output behavior for legitimate session IDs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
