### PR TITLE
Potential fix for code scanning alert no. 59: Uncontrolled data used in path expression

### DIFF
--- a/tests/test_agent_mode.py
+++ b/tests/test_agent_mode.py
@@ -183,7 +183,10 @@ async def test_agent_turn_retry_and_deactivation_on_failure(mock_get_decision, a
         await db.close()
 
         # Clean old issues log if exists
-        session_dir = os.path.join(settings.DATA_DIR, "adventures", "sessions", game_id)
+        sessions_root = os.path.abspath(os.path.normpath(os.path.join(settings.DATA_DIR, "adventures", "sessions")))
+        session_dir = os.path.abspath(os.path.normpath(os.path.join(sessions_root, game_id)))
+        if os.path.commonpath([sessions_root, session_dir]) != sessions_root:
+            raise ValueError(f"Unsafe session path for game_id: {game_id}")
         agents_md_path = os.path.join(session_dir, "AGENTS.md")
         if os.path.exists(agents_md_path):
             os.remove(agents_md_path)


### PR DESCRIPTION
Potential fix for [https://github.com/jschm42/taleweaver/security/code-scanning/59](https://github.com/jschm42/taleweaver/security/code-scanning/59)

Use a safe-root validation pattern before any filesystem access in the test:

- Build a normalized absolute base directory for sessions.
- Build a normalized absolute session path from `game_id`.
- Enforce containment (session path must stay under base path).
- Then build/open `AGENTS.md` from that validated session path.

Best single fix (without changing functionality): update `tests/test_agent_mode.py` around lines 186–187 to normalize/check path containment before using `agents_md_path`. No new dependencies are needed; `os.path.abspath` + `os.path.normpath` + prefix check is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
