### PR TITLE
Potential fix for code scanning alert no. 55: Uncontrolled data used in path expression

### DIFF
--- a/backend/api/routes/adventures/sessions.py
+++ b/backend/api/routes/adventures/sessions.py
@@ -692,7 +692,7 @@ async def delete_session(game_id: str, db: AsyncSession = Depends(get_db), curre
     await db.commit()
 
     # Remove session-bound files from disk.
-    safe_game_id = _sanitize_path_component(game_id)
+    safe_game_id = _sanitize_path_component(str(game_session.id))
     if safe_game_id:
         session_dir = _ensure_within_data_dir(
             os.path.join(settings.DATA_DIR, "adventures", "sessions", safe_game_id)


### PR DESCRIPTION
Potential fix for [https://github.com/jschm42/taleweaver/security/code-scanning/55](https://github.com/jschm42/taleweaver/security/code-scanning/55)

Best fix: eliminate dependence on raw user path text by deriving the directory name from a canonical identifier you already trust from the database object (`game_session.id`), not from the incoming route parameter. Keep the existing sanitizer and root containment check as defense in depth.

Specific change in `backend/api/routes/adventures/sessions.py`:
- In `delete_session`, replace `safe_game_id = _sanitize_path_component(game_id)` with `safe_game_id = _sanitize_path_component(str(game_session.id))`.
- Everything else in cleanup can remain unchanged.

This preserves functionality (same directory naming convention) while reducing direct untrusted-input usage at the filesystem sink.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
