### PR TITLE
Potential fix for code scanning alert no. 52: Uncontrolled data used in path expression

### DIFF
--- a/backend/utils/svg_generator.py
+++ b/backend/utils/svg_generator.py
@@ -4,6 +4,8 @@ import os
 import random
 import re
 
+from backend.core.config import settings
+
 
 class SVGPlaceholderGenerator:
     """
@@ -193,7 +195,15 @@ class SVGPlaceholderGenerator:
 
     def save(self, filepath: str, title: str = "", category: str = "") -> None:
         """Speichert das SVG in eine Datei."""
-        os.makedirs(os.path.dirname(filepath), exist_ok=True)
-        with open(filepath, 'w', encoding='utf-8') as f:
+        data_root = os.path.abspath(settings.DATA_DIR)
+        resolved_path = os.path.abspath(filepath)
+        try:
+            if os.path.commonpath([resolved_path, data_root]) != data_root:
+                raise ValueError("Invalid filepath: path escapes DATA_DIR.")
+        except ValueError as exc:
+            raise ValueError("Invalid filepath: cannot resolve against DATA_DIR.") from exc
+
+        os.makedirs(os.path.dirname(resolved_path), exist_ok=True)
+        with open(resolved_path, 'w', encoding='utf-8') as f:
             f.write(self.generate(title, category))
 

--- a/backend/utils/svg_generator.py
+++ b/backend/utils/svg_generator.py
@@ -195,15 +195,18 @@ class SVGPlaceholderGenerator:
 
     def save(self, filepath: str, title: str = "", category: str = "") -> None:
         """Speichert das SVG in eine Datei."""
-        data_root = os.path.abspath(settings.DATA_DIR)
-        resolved_path = os.path.abspath(filepath)
+        data_root = os.path.realpath(settings.DATA_DIR)
+        resolved_path = os.path.realpath(filepath)
         try:
             if os.path.commonpath([resolved_path, data_root]) != data_root:
                 raise ValueError("Invalid filepath: path escapes DATA_DIR.")
         except ValueError as exc:
             raise ValueError("Invalid filepath: cannot resolve against DATA_DIR.") from exc
 
-        os.makedirs(os.path.dirname(resolved_path), exist_ok=True)
+        parent_dir = os.path.dirname(resolved_path)
+        if not parent_dir:
+            raise ValueError("Invalid filepath: missing parent directory.")
+        os.makedirs(parent_dir, exist_ok=True)
         with open(resolved_path, 'w', encoding='utf-8') as f:
             f.write(self.generate(title, category))
 


### PR DESCRIPTION
Potential fix for [https://github.com/jschm42/taleweaver/security/code-scanning/52](https://github.com/jschm42/taleweaver/security/code-scanning/52)

General fix: validate and normalize any path derived from potentially untrusted data at the point of file access, and enforce that it remains inside an allowed base directory.

Best fix here (without changing intended functionality): in `backend/utils/svg_generator.py`, harden `save()` by:
- Resolving `filepath` to an absolute normalized path.
- Defining a safe root as `settings.DATA_DIR` absolute path.
- Rejecting paths whose common path is not `settings.DATA_DIR`.
- Creating directories and writing only after validation.

This keeps existing behavior for valid in-app paths while preventing traversal/escape writes.  
Needed additions:
- Import `settings` from `backend.core.config`.
- Add containment check logic in `save()` before `os.makedirs`/`open`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
