### PR TITLE
Potential fix for code scanning alert no. 49: Uncontrolled data used in path expression

### DIFF
--- a/backend/engine/media_engine.py
+++ b/backend/engine/media_engine.py
@@ -1161,11 +1161,15 @@ class MediaEngine:
             logger.error("API key resolution failed for provider: %s (Advanced Model/Cover)", provider)
             raise ValueError(f"Missing image configuration or API key for {provider} (Advanced Model/Cover). Please check your Visual Preferences in Admin settings.")
         
-        target_dir = _safe_data_path("adventures", "library", adventure_id)
+        safe_adventure_id = _sanitize_path_component(adventure_id)
+        if not safe_adventure_id:
+            raise ValueError("Invalid adventure identifier.")
+
+        target_dir = _safe_data_path("adventures", "library", safe_adventure_id)
         ext = "jpg" if (t2i.get("image_format") or "jpeg").lower() == "jpeg" else "png"
         
-        # Use adventure_id as prefix for clarity
-        safe_id = slugify(adventure_id)
+        # Use sanitized adventure_id as prefix for clarity
+        safe_id = safe_adventure_id
         filename = f"{safe_id}_cover_{uuid.uuid4().hex[:8]}.{ext}"
         
         prompt = prompts.ADVENTURE_COVER_PROMPT_TEMPLATE.format(


### PR DESCRIPTION
Potential fix for [https://github.com/jschm42/taleweaver/security/code-scanning/49](https://github.com/jschm42/taleweaver/security/code-scanning/49)

Use **strict path-component sanitization for `adventure_id` before building storage paths** in `MediaEngine.generate_adventure_cover`.  
Best fix without changing behavior: sanitize `adventure_id` with existing `_sanitize_path_component`, fail closed on invalid values, and use the sanitized value both for `_safe_data_path(...)` and the filename prefix (instead of raw `slugify(adventure_id)`).

Edit only `backend/engine/media_engine.py` around `generate_adventure_cover` (lines near 1164–1169 in your snippet). No new dependency is required; all helpers already exist in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
