### PR TITLE
Potential fix for code scanning alert no. 45: Uncontrolled data used in path expression

### DIFF
--- a/backend/api/routes/tts_api.py
+++ b/backend/api/routes/tts_api.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from typing import Any, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException
@@ -76,6 +77,23 @@ class TTSGeneratePayload(BaseModel):
     @classmethod
     def _validate_optional_text(cls, value: Any) -> Optional[str]:
         return cls._coerce_optional_text(value)
+
+    @staticmethod
+    def _coerce_optional_uuid(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        candidate = str(value).strip()
+        if not candidate:
+            return None
+        try:
+            return str(uuid.UUID(candidate))
+        except (ValueError, AttributeError, TypeError) as exc:
+            raise ValueError("Must be a valid UUID.") from exc
+
+    @field_validator("adventure_id", "session_id", mode="before")
+    @classmethod
+    def _validate_optional_uuid(cls, value: Any) -> Optional[str]:
+        return cls._coerce_optional_uuid(value)
 
 @router.post("/generate")
 async def generate_tts(


### PR DESCRIPTION
Potential fix for [https://github.com/jschm42/taleweaver/security/code-scanning/45](https://github.com/jschm42/taleweaver/security/code-scanning/45)

General fix: validate and constrain user-controlled identifiers at input boundary to a strict safe format (UUID) before they can influence path logic. This removes tainted path influence rather than only sanitizing later.

Best single fix without changing functionality: in `backend/api/routes/tts_api.py`, enforce that `adventure_id` and `session_id` (when present) are valid UUID strings in `TTSGeneratePayload` validators. This preserves existing behavior for real IDs (which are UUIDs in this codebase usage) while rejecting malformed inputs early with a 422. Since normalized IDs are then guaranteed canonical UUIDs, downstream path construction is no longer using broad-form user strings.

Changes needed:
- File: `backend/api/routes/tts_api.py`
- Add `import uuid`.
- In `TTSGeneratePayload`, add/adjust validator logic for optional ID fields to parse via `uuid.UUID(...)` and return canonical string form.
- No engine changes required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
