### PR TITLE
Potential fix for code scanning alert no. 43: Uncontrolled data used in path expression

### DIFF
--- a/backend/api/routes/adventures/assets.py
+++ b/backend/api/routes/adventures/assets.py
@@ -107,8 +107,8 @@ def _sanitize_path_component(value: str) -> Optional[str]:
 
 
 def _ensure_within_data_dir(path: str) -> str:
-    data_root = os.path.abspath(settings.DATA_DIR)
-    resolved = os.path.abspath(path)
+    data_root = os.path.realpath(settings.DATA_DIR)
+    resolved = os.path.realpath(path)
     try:
         if os.path.commonpath([resolved, data_root]) != data_root:
             raise ValueError("Resolved path escapes DATA_DIR.")


### PR DESCRIPTION
Potential fix for [https://github.com/jschm42/taleweaver/security/code-scanning/43](https://github.com/jschm42/taleweaver/security/code-scanning/43)

Use **canonical path validation with `realpath`** (not only `abspath`) for containment checks, and keep the existing component sanitization. This preserves behavior while making the “inside `DATA_DIR`” guarantee robust against symlink-based escapes and better satisfies static analysis expectations.

Best single fix in `backend/api/routes/adventures/assets.py`:
- Update `_ensure_within_data_dir` to:
  - canonicalize both `settings.DATA_DIR` and candidate `path` via `os.path.realpath(...)`,
  - compare via `os.path.commonpath([resolved, data_root]) == data_root`,
  - return the canonical resolved path.
- No endpoint behavior changes are needed; callers already use `_ensure_within_data_dir`.

This addresses both variants (`target_type` and `target_id`) because both data flows converge in `_build_uploaded_visual_path(...)` and are gated by `_ensure_within_data_dir(...)` before `open(...)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
