### PR TITLE
Potential fix for code scanning alert no. 49: Uncontrolled data used in path expression

### DIFF
--- a/backend/engine/media_engine.py
+++ b/backend/engine/media_engine.py
@@ -103,15 +103,13 @@ def _normalize_output_filename(filename: Optional[str], extension: str) -> str:
 
     # Keep only the final segment to prevent directory traversal.
     candidate = os.path.basename(candidate)
-    stem, original_ext = os.path.splitext(candidate)
+    stem, _original_ext = os.path.splitext(candidate)
     stem = _SAFE_FILENAME_RE.sub("_", stem).strip("._")
     if not stem:
         stem = str(uuid.uuid4())
 
-    normalized_ext = original_ext.lower().lstrip(".")
-    if normalized_ext not in {"png", "jpg", "jpeg"}:
-        normalized_ext = ext
-    return f"{stem}.{normalized_ext}"
+    # Always enforce trusted extension selected by server-side format.
+    return f"{stem}.{ext}"
 
 
 def _normalize_svg_filename(filename: Optional[str], default_stem: str) -> str:


### PR DESCRIPTION
Potential fix for [https://github.com/jschm42/taleweaver/security/code-scanning/49](https://github.com/jschm42/taleweaver/security/code-scanning/49)

Use a stricter filename normalization that **does not trust user-provided extension at all**. Keep sanitized stem from user input (for readability), but always force extension from trusted server-side `image_format` argument. This preserves behavior (still writes JPG/PNG according to chosen format) while removing tainted extension flow and reducing path-expression risk.

Best single fix:
- In `backend/engine/media_engine.py`, update `_normalize_output_filename(...)` so the returned extension is always derived from `extension` parameter, not `original_ext`.
- Keep `os.path.basename`, stem sanitization, and UUID fallback unchanged.
- No route-level changes required for this sink; centralizing fix in MediaEngine covers all variants flowing into this write path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
