### PR TITLE
Potential fix for code scanning alert no. 62: Uncontrolled data used in path expression

### DIFF
--- a/backend/utils/svg_generator.py
+++ b/backend/utils/svg_generator.py
@@ -196,7 +196,14 @@ class SVGPlaceholderGenerator:
     def save(self, filepath: str, title: str = "", category: str = "") -> None:
         """Speichert das SVG in eine Datei."""
         data_root = os.path.realpath(settings.DATA_DIR)
-        resolved_path = os.path.realpath(filepath)
+        normalized_path = os.path.normpath(filepath)
+        filename = os.path.basename(normalized_path)
+        if not filename or filename in {".", ".."}:
+            raise ValueError("Invalid filepath: invalid filename.")
+        if any(sep in filename for sep in (os.sep, os.altsep) if sep):
+            raise ValueError("Invalid filepath: filename must be a single path component.")
+
+        resolved_path = os.path.realpath(normalized_path)
         try:
             if os.path.commonpath([resolved_path, data_root]) != data_root:
                 raise ValueError("Invalid filepath: path escapes DATA_DIR.")


### PR DESCRIPTION
Potential fix for [https://github.com/jschm42/taleweaver/security/code-scanning/62](https://github.com/jschm42/taleweaver/security/code-scanning/62)

General fix: enforce strict, centralized validation at the final filesystem sink, using canonical absolute paths and rejecting unsafe filenames/components before any directory creation or file write.

Best targeted fix (without changing intended functionality): in `backend/utils/svg_generator.py` inside `SVGPlaceholderGenerator.save`, add a strict filename validation step and ensure the resolved file path is normalized and confined to `DATA_DIR` before deriving `parent_dir`. This strengthens the sink even if upstream callers change in the future.

What to change:
- **File:** `backend/utils/svg_generator.py`
- **Region:** `save(...)` method (lines ~196–211 in provided snippet)
- Add:
  - `normalized_path = os.path.normpath(filepath)` before `realpath`
  - reject path if basename is empty or contains separators/`..`
  - keep the existing `commonpath` confinement check
  - continue using resolved safe path for `makedirs` and `open`

No new dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
