### PR TITLE
Potential fix for code scanning alert no. 61: Uncontrolled data used in path expression

### DIFF
--- a/backend/engine/world_generator.py
+++ b/backend/engine/world_generator.py
@@ -18,6 +18,7 @@ from backend.core.tts_voices import GOOGLE_TTS_VOICE_NAMES
 from backend.models.adventure_template import AdventureTemplate, GenerationCancelled
 from backend.models.user import User
 from backend.models.world_entity import WorldEntity, WorldExit, WorldScene
+from backend.utils.text_utils import slugify
 
 logger = logging.getLogger(__name__)
 
@@ -1594,8 +1595,9 @@ class WorldGenerator:
                 if not image_url or image_url.startswith("assets/"):
                     # Fallback to high-quality placeholder for Items
                     item_type = str(o.get("item_type") or "PICKABLE").upper()
+                    safe_entity_id = slugify(str(o["id"])) or "entity"
                     image_url = await MediaEngine.generate_placeholder(
-                        template_id, o["id"], os.path.join(settings.DATA_DIR, "adventures", "library", template_id, "entities"),
+                        template_id, safe_entity_id, os.path.join(settings.DATA_DIR, "adventures", "library", template_id, "entities"),
                         category=f"ITEM_{item_type}"
                     )
 


### PR DESCRIPTION
Potential fix for [https://github.com/jschm42/taleweaver/security/code-scanning/61](https://github.com/jschm42/taleweaver/security/code-scanning/61)

General fix: ensure all user-influenced values used in path construction are converted into safe single path components before joining paths, and keep containment checks against `DATA_DIR`.

Best targeted fix (without changing functionality): in `backend/engine/world_generator.py`, sanitize `o["id"]` before passing it to `MediaEngine.generate_placeholder(...)`. This is the highest-value choke point in the shown flow. Use the already-imported `slugify` helper (from `backend.utils.text_utils`) to derive a filesystem-safe identifier and provide a stable fallback if slugification yields empty. This keeps behavior (placeholder generation per object) while removing traversal/metacharacter risk from raw manifest IDs.

Change region:
- `backend/engine/world_generator.py` near lines 1597–1599 in the object placeholder fallback block.
- Add import for `slugify`.
- Add local `safe_entity_id` assignment and pass that instead of raw `o["id"]`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
