### PR TITLE
Potential fix for code scanning alert no. 62: Uncontrolled data used in path expression

### DIFF
--- a/backend/engine/world_generator.py
+++ b/backend/engine/world_generator.py
@@ -1595,7 +1595,7 @@ class WorldGenerator:
                 if not image_url or image_url.startswith("assets/"):
                     # Fallback to high-quality placeholder for Items
                     item_type = str(o.get("item_type") or "PICKABLE").upper()
-                    safe_entity_id = slugify(str(o["id"])) or "entity"
+                    safe_entity_id = MediaEngine.sanitize_path_component(str(o["id"])) or "entity"
                     image_url = await MediaEngine.generate_placeholder(
                         template_id, safe_entity_id, os.path.join(settings.DATA_DIR, "adventures", "library", template_id, "entities"),
                         category=f"ITEM_{item_type}"


### PR DESCRIPTION
Potential fix for [https://github.com/jschm42/taleweaver/security/code-scanning/62](https://github.com/jschm42/taleweaver/security/code-scanning/62)

General fix: ensure any user-influenced string used as a file/directory component is validated with a strict filesystem-safe allowlist before it is passed into path joins or filename templates.

Best single fix (minimal functional change): in `backend/engine/world_generator.py`, replace use of `slugify(str(o["id"]))` for `safe_entity_id` with `MediaEngine.sanitize_path_component(str(o["id"]))` (already available and purpose-built). Keep a fallback (`"entity"`) if sanitization returns empty/None. This preserves behavior (stable readable IDs) while making the component explicitly filesystem-safe and aligned with downstream path checks.

Scope to change:
- File: `backend/engine/world_generator.py`
- Region: around lines 1597–1600 in `apply_manifest`
- No new dependency required; no import changes needed because `MediaEngine` is already used in that block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
